### PR TITLE
stop propagation on tab

### DIFF
--- a/src/components/RichText.ts
+++ b/src/components/RichText.ts
@@ -155,6 +155,11 @@ export class RichText extends Component<RichTextProps> {
             this.updateEditor(props);
             this.quill.on("selection-change", this.handleSelectionChange);
             this.quill.on("text-change", this.handleTextChange);
+            this.quillNode.addEventListener("keydown", function(event){
+                if (event.which === 19) { // tab key
+                    event.stopPropagation(); 
+                } 
+            });
             const toolbar = this.richTextNode && this.richTextNode.querySelector(".ql-toolbar");
             if (toolbar) {
                 // required to disable editor blur events when the toolbar is clicked


### PR DESCRIPTION
fix for #14 to stop the tab key from changing widget focus in mx 7.13.1.

Could not figure out how to build this properly with the npm package scripts that are installed, but the change works when repackaged locally. Is there any documentation for how to use this buildkit?